### PR TITLE
Tambahkan data dummy login pengguna dan admin

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -25,8 +25,60 @@ export interface AuthResponse {
 
 export const authAPI = {
   login: async (credentials: LoginCredentials): Promise<AuthResponse> => {
-    const { data } = await api.post('/auth/login', credentials);
-    return data;
+    // Demo credentials fallback (works alongside existing API)
+    const demoUsers: Array<{
+      email: string;
+      password: string;
+      user: AuthResponse['user'];
+      token: string;
+    }> = [
+      {
+        email: 'user@demo.com',
+        password: 'password123',
+        user: {
+          id: 101,
+          email: 'user@demo.com',
+          name: 'Demo User',
+          role: 'USER',
+          avatar: 'https://api.dicebear.com/7.x/thumbs/svg?seed=DemoUser'
+        },
+        token: 'demo-token-user'
+      },
+      {
+        email: 'admin@demo.com',
+        password: 'admin123',
+        user: {
+          id: 1,
+          email: 'admin@demo.com',
+          name: 'Demo Admin',
+          role: 'ADMIN',
+          avatar: 'https://api.dicebear.com/7.x/thumbs/svg?seed=DemoAdmin'
+        },
+        token: 'demo-token-admin'
+      }
+    ];
+
+    const matchedDemo = demoUsers.find(
+      d => d.email === credentials.email && d.password === credentials.password
+    );
+
+    // If credentials match demo accounts, short-circuit and return demo response
+    if (matchedDemo) {
+      return {
+        token: matchedDemo.token,
+        user: matchedDemo.user,
+      };
+    }
+
+    // Otherwise try real API
+    try {
+      const { data } = await api.post('/auth/login', credentials);
+      return data;
+    } catch (error) {
+      // If backend is unreachable, still allow demo accounts only
+      // (Non-demo credentials will propagate original error)
+      throw error;
+    }
   },
 
   register: async (userData: RegisterData): Promise<AuthResponse> => {

--- a/src/pages/AdminLoginPage.tsx
+++ b/src/pages/AdminLoginPage.tsx
@@ -9,6 +9,7 @@ import { BookOpen, Eye, EyeOff, Mail, Lock, Shield } from 'lucide-react';
 import { useAppDispatch } from '@/app/hooks';
 import { loginStart, loginSuccess, loginFailure } from '@/features/auth/authSlice';
 import { toast } from '@/hooks/use-toast';
+import { authAPI } from '@/api/auth';
 
 export const AdminLoginPage: React.FC = () => {
   const navigate = useNavigate();
@@ -65,19 +66,7 @@ export const AdminLoginPage: React.FC = () => {
     dispatch(loginStart());
 
     try {
-      const response = await fetch('https://belibraryformentee-production.up.railway.app/api/auth/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      });
-      
-      if (!response.ok) {
-        throw new Error('Login failed');
-      }
-      
-      const data = await response.json();
+      const data = await authAPI.login(formData);
       
       // Check if user is admin
       if (data.user?.role !== 'ADMIN') {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -9,6 +9,7 @@ import { BookOpen, Eye, EyeOff, Mail, Lock } from 'lucide-react';
 import { useAppDispatch } from '@/app/hooks';
 import { loginStart, loginSuccess, loginFailure } from '@/features/auth/authSlice';
 import { toast } from '@/hooks/use-toast';
+import { authAPI } from '@/api/auth';
 
 export const LoginPage: React.FC = () => {
   const navigate = useNavigate();
@@ -65,20 +66,8 @@ export const LoginPage: React.FC = () => {
     dispatch(loginStart());
 
     try {
-      const response = await fetch('https://belibraryformentee-production.up.railway.app/api/auth/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      });
-      
-      if (!response.ok) {
-        throw new Error('Login failed');
-      }
-      
-      const data = await response.json();
-      
+      const data = await authAPI.login(formData);
+
       dispatch(loginSuccess({
         user: data.user,
         token: data.token


### PR DESCRIPTION
Add dummy user and admin login credentials that integrate with the existing authentication API.

---
<a href="https://cursor.com/background-agent?bcId=bc-c03b997e-cce8-471f-a4b3-14e42fbd59e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c03b997e-cce8-471f-a4b3-14e42fbd59e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

